### PR TITLE
Dialog being recreated after lifecycle change fix.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
         android:theme="@style/Theme.MyAlarm.SplashScreen"
         tools:targetApi="33">
         <activity
-            android:name=".MainActivity"
+            android:name=".MainActivity.MainActivity"
             android:exported="true"
             android:theme="@style/Theme.MyAlarm">
             <intent-filter>

--- a/app/src/main/java/com/android/myalarm/MainActivity.kt
+++ b/app/src/main/java/com/android/myalarm/MainActivity.kt
@@ -97,6 +97,13 @@ class MainActivity : AppCompatActivity() {
                 // You can use the API that requires the permission.
             }
 
+            // TODO: Dialog being recreated after lifecycle change (light/dark mode change, orientation change)
+            // happening because the activity gets destroyed and recreated and thus leads to the below
+            // code to check whether permissions are enabled. Checking is fine but shouldn't happen
+            // after a lifecycle change. For example a user can deny it once, switch to landscape and the
+            // prompt will reappear and the user has to respond again after already responding. Also producing a
+            // bug causing multiple instances of the dialog to be created, so i have to cancel/allow x amount of times
+
             shouldShowRequestPermissionRationale(permission) -> {
                 // In an educational UI, explain to the user why your app requires this
                 // permission for a specific feature to behave as expected, and what

--- a/app/src/main/java/com/android/myalarm/MainActivity/MainActivityViewModel.kt
+++ b/app/src/main/java/com/android/myalarm/MainActivity/MainActivityViewModel.kt
@@ -1,0 +1,9 @@
+package com.android.myalarm.MainActivity
+
+import androidx.lifecycle.ViewModel
+
+class MainActivityViewModel : ViewModel(){
+
+    /** variable that tracks that the dialog was displayed to once in the current lifecycle */
+    var isDialogShown = false
+}

--- a/app/src/main/java/com/android/myalarm/NotificationsContextDialogFragment.kt
+++ b/app/src/main/java/com/android/myalarm/NotificationsContextDialogFragment.kt
@@ -86,16 +86,8 @@ class NotificationsContextDialogFragment : DialogFragment(), View.OnClickListene
      * a boolean true
      */
     override fun onClick(view: View?) {
-        when (view?.id) {
-            // dismiss the dialog
-            binding.cancel.id -> dialog?.dismiss()
-            // return to MainActivity that the use wants to allow the notification permission
-            // only care if the user wants to accept the permission, can't really do anything at this
-            // moment if they select to not allow the permission.
-            binding.allow.id -> {
-                setFragmentResult(REQUEST_KEY_PERMISSION_REQUEST, bundleOf(BUNDLE_KEY_PERMISSION_REQUEST to true))
-                dialog?.dismiss()
-            }
-        }
+        val result = view?.id == binding.allow.id
+        setFragmentResult(REQUEST_KEY_PERMISSION_REQUEST, bundleOf(BUNDLE_KEY_PERMISSION_REQUEST to result))
+        dialog?.dismiss()
     }
 }

--- a/app/src/main/java/com/android/myalarm/database/Alarm.kt
+++ b/app/src/main/java/com/android/myalarm/database/Alarm.kt
@@ -1,7 +1,6 @@
 package com.android.myalarm.database
 
 import android.media.RingtoneManager
-import android.net.Uri
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import java.util.UUID

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    tools:context=".MainActivity">
+    tools:context=".MainActivity.MainActivity">
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_navigation"
@@ -26,6 +26,6 @@
         app:defaultNavHost="true"
         android:layout_weight="1"
         app:navGraph="@navigation/nav_graph"
-        tools:context=".MainActivity" />
+        tools:context=".MainActivity.MainActivity" />
 
 </LinearLayout>


### PR DESCRIPTION
 Left a comment with description of problem so i can remind myself of problem. Will also leave it here:

  Dialog being recreated after lifecycle change (light/dark mode change, orientation change) happening because the activity gets destroyed and recreated and thus leads to the below code to check whether permissions are enabled. Checking is fine but shouldn't happen after a lifecycle change. For example a user can deny it once, switch to landscape and the prompt will reappear and the user has to respond again after already responding. Also producing a bug causing multiple instances of the dialog to be created, so i have to cancel/allow x amount of times. This side bug should fix itself when i stop the dialog from reappearing